### PR TITLE
Stop confirm from silently failing

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -88,9 +88,9 @@ module Devise
             self.unconfirmed_email = nil
 
             # We need to validate in such cases to enforce e-mail uniqueness
-            save(validate: true)
+            save!(validate: true)
           else
-            save(validate: args[:ensure_valid] == true)
+            save!(validate: args[:ensure_valid] == true)
           end
 
           after_confirmation if saved


### PR DESCRIPTION
Confirm allows silent failure because though it validates the model on save it doesn't flag up problem in the pre-commit hooks.